### PR TITLE
feat(TypeTask): Display focused item on center of the display

### DIFF
--- a/src/TypeTask.tsx
+++ b/src/TypeTask.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import useKeypress from "react-use-keypress";
 import styled from "styled-components/macro";
 
@@ -139,8 +139,16 @@ const TypeTask = (props: Props) => {
     setTyped(new UserInput());
   }, [props]);
 
+  const cardRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (props.state === State.Active && cardRef.current) {
+      cardRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [props.state]);
+
   return (
-    <TaskCard theme={{ state: props.state }}>
+    <TaskCard theme={{ state: props.state }} ref={cardRef}>
       {props.total && props.index && (
         <div>
           {props.index}/{props.total}

--- a/src/courses/index.ts
+++ b/src/courses/index.ts
@@ -17,8 +17,10 @@ const abcd: Course = {
     {
       title: "Lesson 1 Introducing U and H: Home row, Index fingers",
       sentences: [
-        "uuuu hhhh uuuu hhhh  uuuu hhhh uuuu hhhh",
-        "uuuu hhhh uuuu hhhh  uuuu hhhh uuuu hhhh",
+        "u h",
+        "u h",
+        // "uuuu hhhh uuuu hhhh  uuuu hhhh uuuu hhhh",
+        // "uuuu hhhh uuuu hhhh  uuuu hhhh uuuu hhhh",
         "uh uh uh uh",
         "hu hu hu hu",
         "huh huh huh huh",

--- a/src/courses/index.ts
+++ b/src/courses/index.ts
@@ -17,10 +17,8 @@ const abcd: Course = {
     {
       title: "Lesson 1 Introducing U and H: Home row, Index fingers",
       sentences: [
-        "u h",
-        "u h",
-        // "uuuu hhhh uuuu hhhh  uuuu hhhh uuuu hhhh",
-        // "uuuu hhhh uuuu hhhh  uuuu hhhh uuuu hhhh",
+        "uuuu hhhh uuuu hhhh  uuuu hhhh uuuu hhhh",
+        "uuuu hhhh uuuu hhhh  uuuu hhhh uuuu hhhh",
         "uh uh uh uh",
         "hu hu hu hu",
         "huh huh huh huh",


### PR DESCRIPTION
## Why

focus が次に移ったときにその要素が画面の中央にあってほしい

## What

[`scrollIntoView`](https://developer.mozilla.org/ja/docs/Web/API/Element/scrollIntoView) を使って実現した
![2020-08-12 00 41 50](https://user-images.githubusercontent.com/6651523/89918469-072d2d00-dc35-11ea-92e4-350ebd8ada78.gif)
