### PR TITLE
fix(CourseView): Close item on click outside

### DIFF
--- a/src/CourseView.tsx
+++ b/src/CourseView.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Redirect, Route, Switch, useHistory, useLocation, useParams, useRouteMatch } from "react-router-dom";
 import styled from "styled-components/macro";
 import abcd, { Course, LessonData } from "./courses";
-import Lesson from "./Lesson";
 import Keyboard, { LayoutName } from "./Keyboard";
+import Lesson from "./Lesson";
 
 const courses = new Map<string, Course>([["abcd", abcd]]);
 
@@ -16,23 +16,33 @@ const CourseView = (_: {}) => {
   const previewIdFromQuery = parseInt(useQuery().get("preview") || "", 10);
   const { path, url } = useRouteMatch();
   const [previewLesson, setPreviewLesson] = useState<number | undefined>(previewIdFromQuery || undefined);
+  const lessonBarRef = useRef<HTMLLIElement | null>(null);
   const history = useHistory();
   const course = courses.get(courseSlug);
+
+  useEffect(() => {
+    if (!lessonBarRef.current) {
+      return;
+    }
+    const listener = (e: MouseEvent) => {
+      if (!lessonBarRef.current?.contains(e.target as Node)) {
+        setPreviewLesson(undefined);
+      }
+    };
+    window.addEventListener("click", listener);
+    return () => window.removeEventListener("click", listener);
+    // eslint-disable-next-line
+  }, [lessonBarRef.current]);
+
   if (course === undefined) {
     // TODO: better 404
     return <div>404</div>;
   }
-  const onClickBar = (lesson: number) => {
-    setPreviewLesson((current) => {
-      if (current === lesson) {
-        // TODO: calling history.push breaks `Start` Button
-        // history.push(url);
-        return undefined;
-      }
-      // TODO: calling history.push breaks `Start` Button
-      // history.push(`${url}?preview=${lesson}`);
-      return lesson;
-    });
+  const onClickBar = (lesson: number, e: React.MouseEvent) => {
+    lessonBarRef.current = e.target as HTMLLIElement;
+    // TODO: calling history.push breaks `Start` Button
+    // history.push(`${url}?preview=${lesson}`);
+    setPreviewLesson(lesson);
   };
 
   const lessonList = course.lessons.map((l: LessonData, idx: number) => {
@@ -42,8 +52,8 @@ const CourseView = (_: {}) => {
       <Li key={l.title}>
         <RoundBar
           theme={theme}
-          onClick={() => {
-            onClickBar(idx + 1);
+          onClick={(e: React.MouseEvent) => {
+            onClickBar(idx + 1, e);
           }}
         >
           <FlexSpan>


### PR DESCRIPTION
## Why

リスト中のアイテムをクリックすると詳細が開くが、アイテムを再度クリックすると閉じてしまう。(toggle の動きになっている)
どちらかといえばアイテムの外側をクリックすると閉じてほしい。

## What

外側クリックで閉じれるようにした。

![2020-08-12 23 42 36](https://user-images.githubusercontent.com/6651523/90029259-a285d700-dcf5-11ea-9b47-8776789ac0f8.gif)
